### PR TITLE
Allow Travisci to monitor the module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+before_script:
+  - "git clone git://github.com/puppetlabs/puppetlabs-apt.git spec/fixtures/modules/apt"
+  - "git clone git://github.com/puppetlabs/puppetlabs-mongodb.git spec/fixtures/modules/mongodb"
+  - "git clone git://github.com/puppetlabs/puppetlabs-stdlib.git spec/fixtures/modules/stdlib"
+  - "git clone git://github.com/puppetlabs/puppetlabs-nodejs.git spec/fixtures/modules/nodejs"
+  - "git clone git://github.com/puppetlabs/puppetlabs-tftp.git spec/fixtures/modules/tftp"
+  - "git clone git://github.com/puppetlabs/puppetlabs-vcsrepo.git spec/fixtures/modules/vcsrepo"
+  - "git clone git://github.com/saz/puppet-sudo.git spec/fixtures/modules/sudo"
+after_script:
+script: "rake spec"
+branches:
+  only:
+    - master
+env:
+  - PUPPET_VERSION=2.7.13
+  - PUPPET_VERSION=2.7.6
+  - PUPPET_VERSION=2.6.9
+notifications:
+  email: false


### PR DESCRIPTION
Previously, the module didn't have any automated TravisCI testing (and
it also didn't have any spec tests to be AUTOMATED). There's another
open pull request to commit spec tests for the module, and this commit
introduces a .travis.yml file that can be used to automate tests
according to Ruby and Puppet versions.
