### PR TITLE
Add .gemfile for Travis CI

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -1,0 +1,12 @@
+source :rubygems
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
+
+gem 'puppet', puppetversion
+
+group :test do
+  gem 'rake', '>= 0.9.0'
+  gem 'rspec', '>= 2.8.0'
+  gem 'rspec-puppet', '>= 0.1.1'
+  gem 'mocha', '>= 0.11.0'
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ env:
   - PUPPET_VERSION=2.6.9
 notifications:
   email: false
+gemfile: .gemfile


### PR DESCRIPTION
Previously a .travis.yml file was committed to enable Travis CI
automated testing, but the .gemfile was omitted.  This commit adds that
.gemfile and associates it with .travis.yml
