### PR TITLE
Fix modulefile name to puppetlabs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,15 @@
+2012-06-06 Puppet Labs <info@puppetalbs.com> - 0.1.3
+* Fix modulefile back to puppetlabs.
+* Update syslinux default config.
+* Remove extra files from module.
+
+2012-06-06 Puppet Labs <info@puppetalbs.com> - 0.1.2 (This version not released to forge see 0.1.3)
+* Add Ruby 1.8.7 support (still defaults to 1.9.3)
+* Remove extra gems due to Razor project changes.
+* Add travis testing config.
+
+2012-05-23 Puppet Labs <info@puppetalbs.com> - 0.1.1
+* Add git and make dependencies.
+
+2012-05-23 Puppet Labs <info@puppetalbs.com> - 0.1.0
+* Initial Release.

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
-name    'nanliu-razor'
-version '0.1.2'
+name    'puppetlabs-razor'
+version '0.1.3'
 source  'git@github.com:puppetlabs/puppetlabs-razor.git'
 author  'Puppet Labs'
 license 'Apache 2.0'


### PR DESCRIPTION
During testing for 1.8.7 support a custom module was release to forge
for testing. During merging this change was accidentally included as
part of the Modulefile. This commit reverts this mistake.
