### PR TITLE
No longer pin gem version for macaddr.

### DIFF
--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -44,20 +44,6 @@ class razor::ruby(
     fail("Does not support Ruby ${version} on platform ${::operatingsystem}")
   }
 
-  # Need to specify macaddr 1.5.0 since 1.6.0 went backwards in dependencies.
-  package { 'macaddr':
-    ensure   => '1.5.0',
-    provider => 'gem',
-    require  => Anchor['ruby'],
-  }
-
-  # Deploy uuid after macaddr so we don't pick up 1.6.0.
-  package { 'uuid':
-    ensure   => present,
-    provider => 'gem',
-    require  => Anchor['ruby'],
-  }
-
   if ! defined(Package['make']) {
     package { 'make':
       ensure => present,
@@ -65,8 +51,8 @@ class razor::ruby(
   }
 
   package { [ 'autotest', 'base62', 'bson', 'bson_ext', 'colored',
-              'daemons', 'json', 'logger', 'mocha', 'mongo',
-              'net-ssh', 'require_all', 'syntax'
+              'daemons', 'json', 'logger', 'macaddr', 'mocha', 'mongo',
+              'net-ssh', 'require_all', 'syntax', 'uuid'
             ]:
     ensure   => present,
     provider => gem,

--- a/spec/classes/razor_ruby_spec.rb
+++ b/spec/classes/razor_ruby_spec.rb
@@ -2,17 +2,9 @@ require 'spec_helper'
 
 describe 'razor::ruby', :type => :class do
   it { should contain_package('make') }
-  it { should contain_package('macaddr').with(
-    :ensure   => '1.5.0',
-    :provider => 'gem')
-  }
-  it { should contain_package('uuid').with(
-    :ensure   => 'present',
-    :provider => 'gem')
-  }
   [ 'autotest', 'base62', 'bson', 'bson_ext', 'colored',
-    'daemons', 'json', 'logger', 'mocha', 'mongo',
-    'net-ssh', 'require_all', 'syntax'
+    'daemons', 'json', 'logger', 'macaddr', 'mocha', 'mongo',
+    'net-ssh', 'require_all', 'syntax', 'uuid'
   ].each do |pkg|
     it { should contain_package(pkg).with(
       :ensure   => 'present',


### PR DESCRIPTION
Due to fixes upstream, we no longer pin macaddr gem version.
