### PR TITLE
Add rz_image resource type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,38 @@ Puppet master, add razor class to target node:
 * username: razor daemon username, default: razor.
 * directory; installation target directory, default: /opt/razor.
 * address: razor.ipxe chain address, default: facter ipaddress.
+* mk_source: razor mk iso source, default: [Razor-Microkernel project](https://github.com/downloads/puppetlabs/Razor-Microkernel) production iso.
+
+
+    file { 'custom_mk.iso':
+      path   => '/var/tmp/custom_mk.iso',
+      source => 'puppet:///acme_co/files/custom_mk.iso',
+    }
 
     class { 'razor':
-      directory    => '/usr/local/razor',
+      directory => '/usr/local/razor',
+      mk_source => '/var/tmp/custom_mk.iso',
+      require   => File['custom_mk.iso'],
     }
+
+## Resources
+
+rz_image allows management of images available for razor:
+
+    rz_image { 'VMware-VMvisor-Installer-5.0.0-469512.x86_64.iso':
+      ensure  => 'present',
+      type    => 'esxi',
+      source  => '/opt/image/VMware-VMvisor-Installer-5.0.0-469512.x86_64.iso',
+    }
+
+    rz_image { 'Precise':
+      ensure  => 'present',
+      type    => 'os',
+      version => '12.04',
+      source  => '/opt/image/ubuntu-12.04-server-amd64.iso',
+    }
+
+* Although we can query uuid, it can not be specified.
 
 ## Usage
 

--- a/lib/puppet/provider/rz_image/default.rb
+++ b/lib/puppet/provider/rz_image/default.rb
@@ -1,0 +1,80 @@
+require 'fileutils'
+
+Puppet::Type.type(:rz_image).provide(:default) do
+
+  commands :razor => 'razor'
+  commands :curl => 'curl'
+
+  @image_type = {
+    'MicroKernel Image'         => 'mk',
+    'OS Install'                => 'os',
+    'VMware Hypervisor Install' => 'esxi',
+  }
+
+  mk_resource_methods
+
+  def self.instances
+    razor_images = Array.new
+    images = razor 'image', 'get'
+    images = images.split("\n\n").collect{ |x| Hash[*(x.split(/\n|=>/) - ['Images']).collect{|y| y.strip!}] }
+
+    images.each do |i|
+      image = {
+        :name => i['OS Name'] || i['ISO Filename'],
+        :ensure => :present,
+        :version => i['Version'] || i['OS Version'],
+        :type => @image_type[i['Type']],
+        :uuid => i['UUID'],
+      }
+
+      razor_images << new(image)
+    end
+    razor_images
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  # Clear out the cached values.
+  def flush
+    @property_hash.clear
+  end
+
+  def create
+    @property_hash[:ensure] = :present
+
+    begin
+      if resource[:source] =~ /^http/
+        tmpdir = Dir.mktmpdir(nil, '/var/tmp')
+        source = File.join(tmpdir, resource[:name])
+        curl '-L', resource[:source], '-a', '-o', source
+      else
+        source = resource[:source]
+      end
+      case resource[:type]
+      when 'os'
+        Puppet.debug "razor image add #{resource[:type]} #{resource[:source]} #{resource[:name]} #{resource[:version]}"
+        razor 'image', 'add', resource[:type], source, resource[:name], resource[:version]
+      else
+        Puppet.debug "razor image add #{resource[:type]} #{resource[:source]}"
+        razor 'image', 'add', resource[:type], source
+      end
+    ensure
+      FileUtils.remove_entry_secure(tmpdir) if tmpdir
+    end
+  end
+
+  def destroy
+    @property_hash[:ensure] = :absent
+    razor 'image', 'remove', @property_hash[:uuid]
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+end

--- a/lib/puppet/puppet_x/puppet_labs.rb
+++ b/lib/puppet/puppet_x/puppet_labs.rb
@@ -1,0 +1,4 @@
+module PuppetX
+  module Pupppetlabs
+  end
+end

--- a/lib/puppet/puppet_x/puppet_labs/razor.rb
+++ b/lib/puppet/puppet_x/puppet_labs/razor.rb
@@ -1,0 +1,8 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname.expand_path
+
+module PuppetX::Pupppetlabs
+  class Razor
+
+  end
+end

--- a/lib/puppet/type/rz_image.rb
+++ b/lib/puppet/type/rz_image.rb
@@ -1,0 +1,41 @@
+require 'puppet/type'
+require 'pathname'
+require Pathname.new(__FILE__).dirname.dirname.expand_path + 'puppet_x/puppet_labs/razor'
+
+Puppet::Type.newtype(:rz_image) do
+  @doc = <<-EOT
+    Manages razor images.
+EOT
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the os."
+
+    validate do |path|
+    end
+  end
+
+  newparam(:source) do
+    desc "The image source, can be either local absolute path or remote http(s) source."
+    validate do |value|
+      raise Puppet::Error, "only support local path or http(s) source" unless value =~ /^(\/|http:|https:)/
+    end
+  end
+
+  newproperty(:type) do
+    newvalues('mk', 'os', 'esxi')
+    defaultto('mk')
+  end
+
+  newproperty(:version) do
+
+  end
+
+  newproperty(:uuid) do
+    desc "The image UUID. This property is not expected to be speciified by the user."
+    validate do |value|
+      raise Puppet::Error, "Do not specify UUID value."
+    end
+  end
+end


### PR DESCRIPTION
The rz_image resource type allows us to import razor mk iso images from
either local source or remote http(s) source. This also allows import of
esx and os images, but it's not recommended to do so via http.
