### PR TITLE
Update config file to use correct image host

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,4 +118,17 @@ class razor (
     source  => $mk_source,
     require => [ File['/usr/local/bin/razor'], Package['curl'], Service['razor'] ],
   }
+  
+  exec { 'image_svc_host':
+    command => "/bin/sed -i 's/image_svc_host: .*/image_svc_host: $address/' /opt/razor/conf/razor_server.conf",
+    unless  => "/bin/grep -q 'image_svc_host: $address' /opt/razor/conf/razor_server.conf",
+    notify  => Service['razor'],
+  }
+
+  exec { 'mk_url':
+    command => "/bin/sed -i 's#mk_uri: http://.*:8026#mk_uri: http://$address:8026#' /opt/razor/conf/razor_server.conf",
+    unless  => "/bin/grep -q 'mk_uri: http://$address:8026' /opt/razor/conf/razor_server.conf",
+    notify  => Service['razor'],
+  }
+
 }

--- a/spec/classes/razor_spec.rb
+++ b/spec/classes/razor_spec.rb
@@ -114,6 +114,16 @@ describe 'razor', :type => :class do
         :require => ['Class[Mongodb]', 'File[/var/lib/razor]', 'Sudo::Conf[razor]'],
         :subscribe => ['Class[Razor::Nodejs]', 'Vcsrepo[/var/lib/razor]']
       )
+      should contain_exec('image_svc_host').with(
+        :command => "/bin/sed -i 's/image_svc_host: .*/image_svc_host: #{params[:address]}/' /opt/razor/conf/razor_server.conf",
+        :unless  => "/bin/grep -q 'image_svc_host: #{params[:address]}' /opt/razor/conf/razor_server.conf",
+        :notify  => 'Service[razor]'
+      )
+      should contain_exec('mk_url').with(
+        :command => "/bin/sed -i 's#mk_uri: http://.*:8026#mk_uri: http://#{params[:address]}:8026#' /opt/razor/conf/razor_server.conf",
+        :unless  => "/bin/grep -q 'mk_uri: http://#{params[:address]}:8026' /opt/razor/conf/razor_server.conf",
+        :notify  => 'Service[razor]'
+      )
     }
   end
 


### PR DESCRIPTION
If razor is installed on a machine with two interfaces it will use the first interfaces ip in the config file. This will courses the installing machines to fail. I have done it this way because we need to wait to razor to create the file, on first run then we can update it. If anyone can think of a better option with out shipping the config file with this module which i didn't want to do as i believe its still in a state of "flux". 
