### PR TITLE
Fix spec test for ruby dependency changes.

### DIFF
--- a/spec/classes/razor_ruby_spec.rb
+++ b/spec/classes/razor_ruby_spec.rb
@@ -1,20 +1,28 @@
 require 'spec_helper'
 
 describe 'razor::ruby', :type => :class do
-  it {
-    should contain_package('make')
-    should include_class('ruby')
-  }
-  [ 'autotest', 'base62', 'bson', 'bson_ext', 'colored',
-    'daemons', 'json', 'logger', 'macaddr', 'mocha', 'mongo',
-    'net-ssh', 'require_all', 'syntax', 'uuid'
-  ].each do |pkg|
-    it {
-      should contain_package(pkg).with(
-        :ensure   => 'present',
-        :provider => 'gem',
-        :require  => [ 'Class[Ruby]', 'Package[make]' ]
-      )
-    }
+
+  ['Debian', 'Redhat'].each do |osfamily|
+    context "on #{osfamily} operatingsystems" do
+      let(:facts) do
+        { :osfamily => osfamily }
+      end
+      it {
+        should contain_package('make')
+        should include_class('ruby')
+      }
+      it {
+        [ 'autotest', 'base62', 'bson', 'bson_ext', 'colored',
+          'daemons', 'json', 'logger', 'macaddr', 'mocha', 'mongo',
+          'net-ssh', 'require_all', 'syntax', 'uuid'
+        ].each do |pkg|
+          should contain_package(pkg).with(
+            :ensure   => 'present',
+            :provider => 'gem',
+            :require  => [ 'Class[Ruby]', 'Package[make]' ]
+          )
+        end
+      }
+    end
   end
 end


### PR DESCRIPTION
Becuase we changed the ruby class, now we need to update spec tests to
use osfamily facts.
