### PR TITLE
Add xinetd dependency to fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,5 +8,6 @@ fixtures:
     "sudo": "git://github.com/saz/puppet-sudo.git"
     "tftp": "git://github.com/puppetlabs/puppetlabs-tftp.git"
     "vcsrepo": "git://github.com/puppetlabs/puppetlabs-vcsrepo.git"
+    "xinetd": "git://github.com/puppetlabs/puppetlabs-xinetd.git"
   symlinks:
     "razor": "#{source_dir}"


### PR DESCRIPTION
Tests have been failing due to the missing xinetd fixture.
