### PR TITLE
CentOS 6 - Needs ruby-devel

### DIFF
--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -13,6 +13,7 @@
 class razor::ruby {
 
   include ::ruby
+  include ::ruby::dev
 
   if ! defined(Package['make']) {
     package { 'make':
@@ -26,6 +27,6 @@ class razor::ruby {
             ]:
     ensure   => present,
     provider => gem,
-    require  => [ Class['::ruby'], Package['make'] ],
+    require  => [ Class['::ruby'], Class['::ruby::dev'], Package['make'] ],
   }
 }


### PR DESCRIPTION
What it says on the tin. Fresh install from a minimal image.

```
notice: /Stage[main]/Ruby/Exec[ruby::update_rubygems]: Triggered 'refresh' from 1 events
err: /Stage[main]/Razor::Ruby/Package[bson_ext]/ensure: change from absent to present failed: Execution of '/usr/bin/gem install --include-dependencies --no-rdoc --no-ri bson_ext' returned 1: ERROR:  Error installing bson_ext:
ERROR: Failed to build gem native extension.

        /usr/bin/ruby extconf.rb
        mkmf.rb can't find header files for ruby at /usr/lib/ruby/ruby.h


        Gem files will remain installed in /usr/lib64/ruby/gems/1.8/gems/bson_ext-1.6.4 for inspection.
        Results logged to /usr/lib64/ruby/gems/1.8/gems/bson_ext-1.6.4/ext/cbson/gem_make.out
        INFO:  `gem install -y` is now default and will be removed
        INFO:  use --ignore-dependencies to install only the gems you list
        Building native extensions.  This could take a while...

        err: /Stage[main]/Razor::Ruby/Package[json]/ensure: change from absent to present failed: Execution of '/usr/bin/gem install --include-dependencies --no-rdoc --no-ri json' returned 1: ERROR:  Error installing json:
        ERROR: Failed to build gem  native extension.

                /usr/bin/ruby extconf.rb
                mkmf.rb can't find header files for ruby at /usr/lib/ruby/ruby.h


                Gem files will remain installed in /usr/lib64/ruby/gems/1.8/gems/json-1.7.4 for inspection.
                Results logged to /usr/lib64/ruby/gems/1.8/gems/json-1.7.4/ext/json/ext/generator/gem_make.out
                INFO:  `gem install -y` is now default and will be removed
                INFO:  use --ignore-dependencies to install only the gems you list
                Building native extensions.  This could take a while...
```
