### PR TITLE
Fix rz_image handling of os images

### DIFF
--- a/lib/puppet/provider/rz_image/default.rb
+++ b/lib/puppet/provider/rz_image/default.rb
@@ -64,11 +64,11 @@ Puppet::Type.type(:rz_image).provide(:default) do
       end
       case resource[:type]
       when :os
-        Puppet.debug "razor image add #{resource[:type]} #{resource[:source]} #{resource[:name]} #{resource[:version]}"
-        razor 'image', 'add', resource[:type], source, resource[:name], resource[:version]
+        Puppet.debug "razor image add -t #{resource[:type]} -p #{resource[:source]} -n #{resource[:name]} -v #{resource[:version]}"
+        razor 'image', 'add', '-t', resource[:type], '-p', source, '-n', resource[:name], '-v', resource[:version]
       else
-        Puppet.debug "razor image add #{resource[:type]} #{resource[:source]}"
-        razor 'image', 'add', resource[:type], source
+        Puppet.debug "razor image add -t #{resource[:type]} -p #{resource[:source]}"
+        razor 'image', 'add', '-t', resource[:type], '-p', source
       end
     ensure
       FileUtils.remove_entry_secure(tmpdir) if tmpdir

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,8 +37,8 @@ class razor (
   $address             = $::ipaddress,
   $persist_host        = '127.0.0.1',
   $mk_checkin_interval = '60',
-  $mk_name             = 'rz_mk_prod-image.0.9.0.4.iso',
-  $mk_source           = 'https://github.com/downloads/puppetlabs/Razor-Microkernel/rz_mk_prod-image.0.9.0.4.iso',
+  $mk_name             = 'rz_mk_prod-image.0.9.1.6.iso',
+  $mk_source           = 'https://github.com/downloads/puppetlabs/Razor-Microkernel/rz_mk_prod-image.0.9.1.6.iso',
   $git_source          = 'http://github.com/puppetlabs/Razor.git',
   $git_revision        = 'master'
 ) {


### PR DESCRIPTION
Parse out the original filename from sources that are URLs since 'razor image add' expects an os type to have an iso extension.
