### PR TITLE
Drop development-only gems from the module

### DIFF
--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -21,9 +21,20 @@ class razor::ruby {
     }
   }
 
-  package { [ 'autotest', 'base62', 'bson', 'bson_ext', 'colored',
-              'daemons', 'json', 'logger', 'macaddr', 'mocha', 'mongo',
-              'net-ssh', 'require_all', 'syntax', 'uuid'
+  package { [
+             'base62',
+             'bson',
+             'bson_ext',
+             'colored',
+             'daemons',
+             'json',
+             'logger',
+             'macaddr',
+             'mongo',
+             'net-ssh',
+             'require_all',
+             'syntax',
+             'uuid'
             ]:
     ensure   => present,
     provider => gem,

--- a/spec/classes/razor_ruby_spec.rb
+++ b/spec/classes/razor_ruby_spec.rb
@@ -12,8 +12,8 @@ describe 'razor::ruby', :type => :class do
         should include_class('ruby')
       }
       it {
-        [ 'autotest', 'base62', 'bson', 'bson_ext', 'colored',
-          'daemons', 'json', 'logger', 'macaddr', 'mocha', 'mongo',
+        [ 'base62', 'bson', 'bson_ext', 'colored',
+          'daemons', 'json', 'logger', 'macaddr', 'mongo',
           'net-ssh', 'require_all', 'syntax', 'uuid'
         ].each do |pkg|
           should contain_package(pkg).with(


### PR DESCRIPTION
The `autotest` and `mocha` gems are only required for testing, not for running
Razor in production.  We shouldn't install them from this module.

Signed-off-by: Daniel Pittman daniel@rimspace.net
