### PR TITLE
Extract version number directly from git

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,17 +1,25 @@
+# -*- ruby -*-
 name    'puppetlabs-razor'
-version '0.3.0'
-source  'git@github.com:puppetlabs/puppetlabs-razor.git'
-author  'Puppet Labs'
-license 'Apache 2.0'
-summary 'Razor puppet module'
-description 'Razor provisioning system puppet installation module'
+source       'git@github.com:puppetlabs/puppetlabs-razor.git'
+author       'Puppet Labs'
+license      'Apache 2.0'
+summary      'Razor puppet module'
+description  'Razor provisioning system puppet installation module'
 project_page 'https://github.com/puppetlabs/puppetlabs-razor'
 
+# Grab the version number from git, and bump up the tiny version number if we
+# have a postfix string, since Puppet only supports SemVer 1.0.0, which
+# doesn't have anything but "version" and "pre-release of version".
+#
+# Technically this isn't accurately reflecting the real next release number,
+# but whatever - it will do for now.
+version %x{git describe --dirty --tags}.chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
+
 ## Add dependencies, if any:
-dependency 'puppetlabs/stdlib', '>= 2.0.0'
+dependency 'puppetlabs/stdlib',  '>= 2.0.0'
 dependency 'puppetlabs/mongodb', '>= 0.1.0'
-dependency 'puppetlabs/nodejs', '>= 0.1.1'
-dependency 'puppetlabs/ruby', '>= 0.0.2'
-dependency 'puppetlabs/tftp', '>= 0.2.0'
+dependency 'puppetlabs/nodejs',  '>= 0.1.1'
+dependency 'puppetlabs/ruby',    '>= 0.0.2'
+dependency 'puppetlabs/tftp',    '>= 0.2.0'
 dependency 'puppetlabs/vcsrepo', '>= 0.0.5'
-dependency 'saz/sudo', '>= 2.0.0'
+dependency 'saz/sudo',           '>= 2.0.0'


### PR DESCRIPTION
This uses `git describe` to extract the version number, automatically, in the
Modulefile - rather than forcing manual updates.

This handles dirty branches and nightly builds, though not as nicely as
I would like: because Puppet is strictly SemVer 1.0.0, we only have release
and pre-release versioning.

So, when a nightly is run we assume that the "trivial" version is bumped, and
mark as a pre-release of that.  This is the smallest step possible and ensures
that a full release will _never_ be "less" than a nightly build.

Optimally we would postfix a SemVer 2.0.0 build version, but until that is in
all versions of Puppet in the field ... we are stuck with this.

Signed-off-by: Daniel Pittman daniel@rimspace.net
