### PR TITLE
Better error detection and discovery for git versioning

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 # -*- ruby -*-
-name    'puppetlabs-razor'
+name         'puppetlabs-razor'
 source       'git@github.com:puppetlabs/puppetlabs-razor.git'
 author       'Puppet Labs'
 license      'Apache 2.0'
@@ -13,7 +13,11 @@ project_page 'https://github.com/puppetlabs/puppetlabs-razor'
 #
 # Technically this isn't accurately reflecting the real next release number,
 # but whatever - it will do for now.
-version %x{git describe --dirty --tags}.chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
+git_version = %x{git describe --dirty --tags}.chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
+unless $?.success? and git_version =~ /^\d+\.\d+\.\d+/
+  raise "Unable to determine version using git: #{$?} => #{git_version.inspect}"
+end
+version    git_version
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib',  '>= 2.0.0'


### PR DESCRIPTION
Our CI systems failed to discover the version number, which is surprising, but
highlights a shortfall in debugging in this code.  This fixes that.

Signed-off-by: Daniel Pittman daniel@rimspace.net
