### PR TITLE
Only use annotated git tags for versioning

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -13,7 +13,8 @@ project_page 'https://github.com/puppetlabs/puppetlabs-razor'
 #
 # Technically this isn't accurately reflecting the real next release number,
 # but whatever - it will do for now.
-git_version = %x{git describe --dirty --tags}.chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
+git_version = %x{git describe --dirty}.
+  chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
 unless $?.success? and git_version =~ /^\d+\.\d+\.\d+/
   raise "Unable to determine version using git: #{$?} => #{git_version.inspect}"
 end


### PR DESCRIPTION
I had turned on the option to use normal, unannotated tags as well as the
fully, heavy annotated tags that we actually use to indicate a release.

This broke when Jenkins internally tagged the repo with the build details,
since that light-weight tag was closer than the real version tag.

This drops that extra option to `git describe` to avoid that problem.

Signed-off-by: Daniel Pittman daniel@rimspace.net
