### PR TITLE
Revert "Only use annotated git tags for versioning"

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -13,8 +13,7 @@ project_page 'https://github.com/puppetlabs/puppetlabs-razor'
 #
 # Technically this isn't accurately reflecting the real next release number,
 # but whatever - it will do for now.
-git_version = %x{git describe --dirty}.
-  chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
+git_version = %x{git describe --dirty --tags}.chomp.sub(/\.([0-9]+)-/) {|v| ".#{v[1..-2].to_i(10) + 1}-" }
 unless $?.success? and git_version =~ /^\d+\.\d+\.\d+/
   raise "Unable to determine version using git: #{$?} => #{git_version.inspect}"
 end


### PR DESCRIPTION
This reverts commit 730aac12ee7b8acdf9b43b59c2e4f9c32d48dc55.
