### PR TITLE
Add support for installing Razor using OS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Puppet master, add razor class to target node:
 
 ## Parameters
 
+* source: `git`, or `package`; default: `git`
+  - this selects what installation method is used for getting Razor on the system
+  - **WARNING**: the default will change from `git` to `package` before the 1.0.0 release of the overall project.
 * username: razor daemon username, default: razor.
 * directory; installation target directory, default: /opt/razor.
 * address: razor.ipxe chain address, and razor service listen address, default: facter ipaddress.
@@ -62,8 +65,10 @@ Puppet master, add razor class to target node:
 * mk_checkin_interval: mk checkin interval, default: 60 seconds.
 * mk_name: razor tiny core linux mk name.
 * mk_source: razor mk iso source, default: [Razor-Microkernel project](https://github.com/downloads/puppetlabs/Razor-Microkernel) production iso.
-* git_source: razor git repo source, default: [Puppet Labs Razor](https://github.com/puppetlabs/Razor.git) .
+* git_source: razor git repo source, default: [Puppet Labs Razor](https://github.com/puppetlabs/Razor.git).
+  - **DEPRECATED**: this feature is deprecated in favour of package installation.
 * git_revision: razor git repo revision, default: master.
+  - **DEPRECATED**: this feature is deprecated in favour of package installation.
 
         file { 'custom_mk.iso':
           path   => '/var/tmp/custom_mk.iso',

--- a/spec/classes/razor_spec.rb
+++ b/spec/classes/razor_spec.rb
@@ -8,7 +8,8 @@ describe 'razor', :type => :class do
       :persist_host        => '127.0.0.1',
       :mk_checkin_interval => '60',
       :git_source          => 'http://github.com/johndoe/Razor.git',
-      :git_revision        => '1ef7d2'
+      :git_revision        => '1ef7d2',
+      :source              => 'git'
     }
   end
 
@@ -72,7 +73,7 @@ describe 'razor', :type => :class do
           :start     => "/var/lib/razor/bin/razor_daemon.rb start",
           :stop      => "/var/lib/razor/bin/razor_daemon.rb stop",
           :require   => ['Class[Mongodb]', 'File[/var/lib/razor]', 'Sudo::Conf[razor]'],
-          :subscribe => ['Class[Razor::Nodejs]', "Vcsrepo[#{params[:directory]}]"]
+          :subscribe => 'Class[Razor::Nodejs]'
         )
         should contain_file("#{params[:directory]}/conf/razor_server.conf").with(
           :ensure  => 'file',


### PR DESCRIPTION
This introduces support for installing Razor using OS packages, along-side the
existing support for installing from git.  At the moment git remains the
default mechanism for installation, as we gradually move toward a more
standard release model.

Closes #91.

Signed-off-by: Daniel Pittman daniel@rimspace.net
