### PR TITLE
Update rz_broker support for metadata.

### DIFF
--- a/lib/puppet/provider/rz_broker/default.rb
+++ b/lib/puppet/provider/rz_broker/default.rb
@@ -46,11 +46,11 @@ Puppet::Type.type(:rz_broker).provide(:default) do
     @property_hash[:ensure] = :present
 
     broker = {
-      'name'        => @resource[:name],
-      'description' => @resource[:name],
-      'servers'     => @resource[:servers].join(','),
-      'plugin'      => @resource[:plugin],
-      'version'     => @resource[:version],
+      'name'              => @resource[:name],
+      'description'       => @resource[:name],
+      'plugin'            => @resource[:plugin],
+      'req_metadata_hash' => @resource[:metadata],
+      'version'           => @resource[:version],
     }
 
     Puppet.debug "razor -w broker add '#{broker.to_pson}'"

--- a/lib/puppet/type/rz_broker.rb
+++ b/lib/puppet/type/rz_broker.rb
@@ -19,12 +19,8 @@ EOT
     newvalues(/\w+/)
   end
 
-  newproperty(:servers, :array_matching => :all) do
-    desc "The broker servers."
-  end
-
-  newproperty(:version) do
-    desc "The version of the broker to use"
+  newproperty(:metadata) do
+    desc "The metadata of the broker to use"
   end
 
   newproperty(:uuid) do

--- a/tests/broker.pp
+++ b/tests/broker.pp
@@ -1,5 +1,7 @@
 rz_broker { 'demo':
   plugin  => 'puppet',
-  servers => 'puppet.dmz25.lab',
+  metadata => {
+    version => '3.0.2',
+    server  => 'puppet.dmz25.lab',
+  }
 }
- 


### PR DESCRIPTION
The razor module chef support changed the data format. Server and
version attribute for rz_broker are now part of the resource metadata.
Also we never properly supported servers, only a single server. This
commit fixes #93.
