### PR TITLE
Update with new official ISO download location

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,8 +40,8 @@ class razor (
   $address             = $::ipaddress,
   $persist_host        = '127.0.0.1',
   $mk_checkin_interval = '60',
-  $mk_name             = 'rz_mk_prod-image.0.9.1.6.iso',
-  $mk_source           = 'https://github.com/downloads/puppetlabs/Razor-Microkernel/rz_mk_prod-image.0.9.1.6.iso',
+  $mk_name             = 'rz_mk_prod-image.0.10.0.iso',
+  $mk_source           = 'https://downloads.puppetlabs.com/razor/iso/rz_mk_prod-image.0.10.0.iso',
   $git_source          = 'http://github.com/puppetlabs/Razor.git',
   $git_revision        = 'master'
 ) {


### PR DESCRIPTION
This updates the default ISO location to downloads.puppetlabs.com, and bumps
to version 0.10.0 of the Microkernel by default.

Signed-off-by: Daniel Pittman daniel@rimspace.net
