### PR TITLE
Quote $@ in templates/razor.erb to avoid whitespace issues

### DIFF
--- a/templates/razor.erb
+++ b/templates/razor.erb
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-<%= @directory %>/bin/razor $@
+<%= @directory %>/bin/razor "$@"


### PR DESCRIPTION
Per:

https://groups.google.com/forum/?hl=en&fromgroups=#!topic/puppet-razor/7Wzo64qlY-M

$@ needs to be quoted to prevent bash from eating the quotes passed on the command line, which in turn causes everything after the space to disappear from --value.

Thank you.
- Jason Parsons
