### PR TITLE
(#112) Added rubygems_update param to razor class.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 #   [*mk_source*]: Razor tinycore linux mk iso file source (local or http).
 #   [*git_source*]: razor repo source. (**DEPRECATED**)
 #   [*git_revision*]: razor repo revision. (**DEPRECATED**)
+#   [*rubygems_update*]: Update rubygems, default depends on osfamily.
 #
 # Actions:
 #
@@ -43,15 +44,17 @@ class razor (
   $mk_name             = 'razor-microkernel-latest.iso',
   $mk_source           = 'https://downloads.puppetlabs.com/razor/iso/prod/razor-microkernel-latest.iso',
   $git_source          = 'http://github.com/puppetlabs/Razor.git',
-  $git_revision        = 'master'
+  $git_revision        = 'master',
+  $rubygems_update     = undef
 ) {
-
   include sudo
-  include 'razor::ruby'
   include 'razor::tftp'
 
-  class { 'mongodb':
-    enable_10gen => true,
+  class {
+    'razor::ruby':
+      rubygems_update => $rubygems_update;
+    'mongodb':
+      enable_10gen => true;
   }
 
   Class['razor::ruby'] -> Class['razor']

--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -10,9 +10,20 @@
 #
 # Usage:
 #   include 'razor::ruby'
-class razor::ruby {
+class razor::ruby (
+  $rubygems_update = undef
+) {
+  include ::ruby::params
 
-  include ::ruby
+  $rubygems_update_real = $rubygems_update ? {
+    undef   => $::ruby::params::rubygems_update,
+    default => $rubygems_update
+  }
+
+  class { '::ruby':
+    rubygems_update => $rubygems_update_real,
+  }
+
   include ::ruby::dev
 
   if ! defined(Package['make']) {
@@ -20,7 +31,7 @@ class razor::ruby {
       ensure => present,
     }
   }
-  
+
   if ! defined(Package['gcc']) {
     package { 'gcc':
       ensure => present,


### PR DESCRIPTION
This change adds the rubygems_update parameter to the razor class so
that it can be propagated to the ::ruby class.

The first motivation is that the current version of rubygems is 2.0.1
which doesn't seem to be compatible with earlier versions. This results
in lots of errors about the --include-dependencies option which is
apparently now implied by default:

  Notice: /Stage[main]/Ruby::Dev/Package[ruby-devel]/ensure: created
    Error: Execution of '/usr/bin/gem install --include-dependencies
      --no-rdoc --no-ri require_all' returned 1:
      ERROR: While executing gem ... (OptionParser::InvalidOption)
        invalid option: --include-dependencies

The second motivation is that it makes it possible to override the default
behavior on CentOS to update rubygems. This override would be desirable
for people who don't necessarily want to pull external dependencies. It
might also be desirable for people who actually want to update rubygems
on other OS families.
