### PR TITLE
Handle SemVer sorting correctly in the changelog generator

### DIFF
--- a/bin/git-log-to-changelog
+++ b/bin/git-log-to-changelog
@@ -1,30 +1,56 @@
-#!/bin/bash
-set -e
-echo -n "generate changelog: " >&2
+#!/usr/bin/env ruby
+STDERR.puts "generate changelog: "
 
-# This makes us mac compatible, too, if they have the right toolchain installed
-if type -p gsort >&/dev/null; then sort=gsort; else sort=sort; fi
+def capture(cmd)
+  result = %x{#{cmd}}
+  fail "unable to execute #{cmd.inspect}: #{$?}" unless $?.success?
+  return result
+end
 
-top=$($(dirname $0)/get-version-from-git)
-for bottom in $(git tag -l | ${sort} -hr) ''; do
-    if [ x"${top}" != x"${bottom}" ]; then
-        echo -n "." >&2
+def compare_as_int(a,b)
+  result = a.to_i <=> b.to_i
+  result == 0 ? nil : result
+end
 
-        # changelog header
-        header="$(git log -1 --date=short --format="%cd %cN <%cE> - ${top}" "${top}")"
-        echo "${header}"
-        echo "$(echo -n "${header}" | sed -e 's/./=/g')"
-        echo ""
+def compare_as_special(a,b)
+  # This probably only supports up to RC9 correctly.
+  if a.nil? and not b.nil?      then  1
+  elsif not a.nil? and b.nil?   then -1
+  elsif a.nil? and b.nil?       then  0
+  else                          a <=> b
+  end
+end
 
-        # changes in this revision; the one space indentation looks *much* nicer overall!
-        git shortlog --no-merges -n -e --format='* %s' -w77,1,3 ${bottom}..${top} | \
-            sed -e 's/^/ /'
+tags = capture('git tag -l').split.sort do |a, b|
+  a = a.split(/[-.]/)
+  b = b.split(/[-.]/)
 
-        echo ""
-    fi
+  compare_as_int(a[0], b[0]) ||
+    compare_as_int(a[1], b[1]) ||
+    compare_as_int(a[2], b[2]) ||
+    compare_as_special(a[3], b[3])
+end.reverse
 
-    top="${bottom}"
-done
+# ...and insert the "base" version before the first version.
+tags.push nil
 
-echo " done." >&2
+tags.each_cons(2) do |top, bottom|
+  STDERR.print '.'
+
+  header = capture("git log -1 --date=short --format=\"%cd %cN <%cE> - #{top}\" \"#{top}\"")
+  puts header
+  puts '=' * header.length
+  puts ''
+
+  changes = capture("git shortlog --no-merges -n -e --format='* %s' -w77,1,3 #{bottom}..#{top}")
+  if changes.empty?
+    puts " * no changes since the previous version."
+  else
+    puts changes.gsub(/^/, ' ')
+  end
+
+  puts ''
+end
+
+STDERR.puts " done."
 exit 0


### PR DESCRIPTION
The shell changelog generator worked fine, but didn't sort correctly: RC
versions were sorted after, not before, their parent.  (In part because SemVer
is a human focused version sort, and it is actually hard to find a portable
shell implementation of that sorting.)

This replaces it with a small Ruby script that does the same work, but allows
me to implement a SemVer-correct sorting routine.  It is kind of ugly, because
the logic is ugly, but it works correctly now.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
