### PR TITLE
Install the `net-scp` gem in addition to `net-ssh`

### DIFF
--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -54,6 +54,7 @@ class razor::ruby (
              'macaddr',
              'mongo',
              'net-ssh',
+             'net-scp',
              'require_all',
              'syntax',
              'uuid'


### PR DESCRIPTION
The external script broker, recently added to Razor, adds a new dependency on
the `net-scp` gem in addition to the `net-ssh` library; this extends the later
with an integration of scp file transfer.

This updates the Ruby manifests to install both gems, which ensures that
current Razor continues to run correctly.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
