### PR TITLE
Fix dangling `tmpdir` reference from cache feature

### DIFF
--- a/lib/puppet/provider/rz_image/default.rb
+++ b/lib/puppet/provider/rz_image/default.rb
@@ -77,8 +77,6 @@ Puppet::Type.type(:rz_image).provide(:default) do
         Puppet.debug "razor image add -t #{resource[:type]} -p #{resource[:source]}"
         razor 'image', 'add', '-t', resource[:type], '-p', source
       end
-    ensure
-      FileUtils.remove_entry_secure(tmpdir) if tmpdir
     end
   end
 


### PR DESCRIPTION
The added cache feature tried to reference a temporary directory that no
longer existed; this corrects that bug by excising the additional code.

Since this was unused, no ill effects flow from this.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
