### PR TITLE
(#130) Razor providers should check return value for errors

### DIFF
--- a/lib/puppet/provider/rz_broker/default.rb
+++ b/lib/puppet/provider/rz_broker/default.rb
@@ -53,13 +53,14 @@ Puppet::Type.type(:rz_broker).provide(:default) do
     }
 
     Puppet.debug "razor -w broker add '#{broker.to_pson}'"
-    command = ['razor', '-w', 'broker', 'add', "'#{broker.to_pson}'"].join(" ")
-    execute(command, :combine => true)
+    output = razor '-w', 'broker', 'add', broker.to_pson
+    query_razor.parse(output)
   end
 
   def destroy
     @property_hash[:ensure] = :absent
-    razor '-w', 'broker', 'remove', @property_hash[:uuid]
+    output = razor '-w', 'broker', 'remove', @property_hash[:uuid]
+    query_razor.parse(output)
   end
 
   def exists?

--- a/lib/puppet/provider/rz_image/default.rb
+++ b/lib/puppet/provider/rz_image/default.rb
@@ -69,20 +69,27 @@ Puppet::Type.type(:rz_image).provide(:default) do
         download(resource[:url], target)
       end
 
-      case resource[:type]
-      when :os
-        Puppet.debug "razor image add -t #{resource[:type]} -p #{resource[:source]} -n #{resource[:name]} -v #{resource[:version]}"
-        razor 'image', 'add', '-t', resource[:type], '-p', source, '-n', resource[:name], '-v', resource[:version]
-      else
-        Puppet.debug "razor image add -t #{resource[:type]} -p #{resource[:source]}"
-        razor 'image', 'add', '-t', resource[:type], '-p', source
+      options = [
+        '-t', resource[:type],
+        '-p', resource[:source],
+        ]
+      if resource[:type] === :os
+        options += [
+          '-n', resource[:name],
+          '-v', resource[:version],
+          ]
       end
+
+      Puppet.debug "razor image add #{options.join(' ')}"
+      output = razor 'image', 'add', *options
+      query_razor.parse(output)
     end
   end
 
   def destroy
     @property_hash[:ensure] = :absent
-    razor 'image', 'remove', @property_hash[:uuid]
+    output = razor 'image', 'remove', @property_hash[:uuid]
+    query_razor.parse(output)
   end
 
   def exists?

--- a/lib/puppet/provider/rz_model/default.rb
+++ b/lib/puppet/provider/rz_model/default.rb
@@ -68,13 +68,14 @@ Puppet::Type.type(:rz_model).provide(:default) do
     }
 
     Puppet.debug "razor -w model add '#{model.to_pson}'"
-    command = ['razor', '-w', 'model', 'add', "'#{model.to_pson}'"].join(" ")
-    execute(command, :combine => true)
+    output = razor '-w', 'model', 'add', model.to_pson
+    query_razor.parse(output)
   end
 
   def destroy
     @property_hash[:ensure] = :absent
-    razor '-w', 'model', 'remove', @property_hash[:uuid]
+    output = razor '-w', 'model', 'remove', @property_hash[:uuid]
+    query_razor.parse(output)
   end
 
   def exists?

--- a/lib/puppet/provider/rz_policy/default.rb
+++ b/lib/puppet/provider/rz_policy/default.rb
@@ -58,13 +58,14 @@ Puppet::Type.type(:rz_policy).provide(:default) do
     }
 
     Puppet.debug "razor -w policy add '#{policy.to_pson}'"
-    command = ['razor', '-w', 'policy', 'add', "'#{policy.to_pson}'"].join(" ")
-    execute(command, :combine => true)
+    output = razor '-w', 'policy', 'add', policy.to_pson
+    query_razor.parse(output)
   end
 
   def destroy
     @property_hash[:ensure] = :absent
-    razor '-w', 'policy', 'remove', @property_hash[:uuid]
+    output = razor '-w', 'policy', 'remove', @property_hash[:uuid]
+    query_razor.parse(output)
   end
 
   def exists?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+end

--- a/spec/unit/provider/rz_broker/default_spec.rb
+++ b/spec/unit/provider/rz_broker/default_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:rz_broker).provider(:default) do
+  let :resource do Puppet::Resource.new(:rz_broker, 'foo') end
+  let :provider do described_class.new(resource) end
+
+  describe "#create" do
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "test",
+        }))
+      provider.create.should == "test"
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Must Provide: [The broker plugin to use.]",
+        }))
+      expect { provider.create }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe "#destroy" do
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "Broker [5QRpDwF2w8kuT8ROh1W7p4] removed",
+        }))
+      provider.destroy.should =~ /removed/
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Cannot Find Broker with UUID: [5QRpDwF2w8kuT8ROh1W7p4]",
+        }))
+      expect { provider.destroy }.to raise_error(Puppet::Error)
+    end
+  end
+end

--- a/spec/unit/provider/rz_image/default_spec.rb
+++ b/spec/unit/provider/rz_image/default_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:rz_image).provider(:default) do
+  let :resource do Puppet::Resource.new(:rz_image, 'foo') end
+  let :provider do described_class.new(resource) end
+
+  describe "#create" do
+    before (:each) do
+      provider.should_receive(:download).and_return('foo')
+      resource[:source] = '/foo'
+    end
+
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "test",
+        }))
+      provider.create.should == "test"
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Invalid Metadata [root_password:'short']",
+        }))
+      expect { provider.create }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe "#destroy" do
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => ""
+        }))
+      provider.destroy.should == ""
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "invalid uuid [\"3qP9NNmv6xTIMfTpoP5k6M\"]",
+        }))
+      expect { provider.destroy }.to raise_error(Puppet::Error)
+    end
+  end
+end

--- a/spec/unit/provider/rz_model/default_spec.rb
+++ b/spec/unit/provider/rz_model/default_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:rz_model).provider(:default) do
+  let :resource do Puppet::Resource.new(:rz_model, 'foo') end
+  let :provider do described_class.new(resource) end
+
+  describe "#create" do
+    before (:each) do
+      # Mock query_razor to return an object with get_image_uuid.
+      query_razor = PuppetX::PuppetLabs::Razor.new(nil)
+      query_razor.should_receive(:get_image_uuid).and_return('image uuid')
+      provider.should_receive(:query_razor).twice.and_return(query_razor)
+    end
+
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "test",
+        }))
+      provider.create.should == "test"
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Invalid Metadata [root_password:'short']",
+        }))
+      expect { provider.create }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe "#destroy" do
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "Active Model [7Vu8BbwLUSEGlfqLLxHbYI] removed",
+        }))
+      provider.destroy.should =~ /removed/
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Cannot Find Model with UUID: [7Vu8BbwLUSEGlfqLLxHbYI]",
+        }))
+      expect { provider.destroy }.to raise_error(Puppet::Error)
+    end
+  end
+end

--- a/spec/unit/provider/rz_policy/default_spec.rb
+++ b/spec/unit/provider/rz_policy/default_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:rz_policy).provider(:default) do
+  let :resource do Puppet::Resource.new(:rz_policy, 'foo') end
+  let :provider do described_class.new(resource) end
+
+  describe "#create" do
+    before (:each) do
+      # Mock query_razor to return an object with get_model_uuid and get_broker_uuid.
+      query_razor = PuppetX::PuppetLabs::Razor.new(nil)
+      query_razor.should_receive(:get_model_uuid).and_return('model uuid')
+      query_razor.should_receive(:get_broker_uuid).and_return('broker uuid')
+      provider.should_receive(:query_razor).exactly(3).times.and_return(query_razor)
+    end
+
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "test",
+        }))
+      provider.create.should == "test"
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Policy Template is not valid [foo]",
+        }))
+      expect { provider.create }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe "#destroy" do
+    it "with response should return the string" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :response => "Active policy [5VtQrjhwifUskC0wnDk2OI] removed",
+        }))
+      provider.destroy.should =~ /removed/
+    end
+
+    it "with result should raise Puppet::Error" do
+      provider.should_receive(:razor).and_return(PSON.dump({
+        :result => "Cannot Find Policy with UUID: [5VtQrjhwifUskC0wnDk2OI]",
+        }))
+      expect { provider.destroy }.to raise_error(Puppet::Error)
+    end
+  end
+end


### PR DESCRIPTION
This change modifies the create and destroy methods in the rz_broker,
rz_image, rz_model and rz_policy providers to raise a Puppet::Error
when an error occurs. This is achieved by passing the output to the
parse method in the PuppetX::PuppetLabs::Razor class. If the output
contains a 'response' key, it is returned, if it contains a 'result' key,
a Puppet::Error exception is raised with it, otherwise a Puppet::Razor
exception is raised with the whole output.

The reason for this change is to enable Puppet manifests using
Razor resources to actually get an error when the razor command
fails. Otherwise, the error is simply ignored and the user has to
reverse engineer the problem from the side effects of the failure.

Note that this change moves the parse method in PuppetX::PuppetLabs::Razor
from being private to public, so that it can be re-used in the
providers. Also note that it did not implement the behavior for the rz_tag
provider because it is much more complicated, having to potentially
manage multiple tags. This can be handled in a separate pull request.

This pull request fixes issue #130.
