### PR TITLE
On a clean Ubuntu 12.04 install net-scp is required.

### DIFF
--- a/spec/classes/razor_ruby_spec.rb
+++ b/spec/classes/razor_ruby_spec.rb
@@ -22,7 +22,7 @@ describe 'razor::ruby', :type => :class do
       it {
         [ 'base62', 'bson', 'bson_ext', 'colored',
           'daemons', 'logger', 'macaddr', 'mongo',
-          'net-ssh', 'require_all', 'syntax', 'uuid'
+          'net-ssh', 'net-scp', 'require_all', 'syntax', 'uuid'
         ].each do |pkg|
           should contain_package(pkg).with(
             :ensure   => 'present',


### PR DESCRIPTION
In order to start razor and download the microkernel, net-scp should be included.
