### PR TITLE
(#133) Razor image provider should not check for errors like other providers

### DIFF
--- a/lib/puppet/provider/rz_image/default.rb
+++ b/lib/puppet/provider/rz_image/default.rb
@@ -81,15 +81,13 @@ Puppet::Type.type(:rz_image).provide(:default) do
       end
 
       Puppet.debug "razor image add #{options.join(' ')}"
-      output = razor 'image', 'add', *options
-      query_razor.parse(output)
+      razor 'image', 'add', *options
     end
   end
 
   def destroy
     @property_hash[:ensure] = :absent
-    output = razor 'image', 'remove', @property_hash[:uuid]
-    query_razor.parse(output)
+    razor 'image', 'remove', @property_hash[:uuid]
   end
 
   def exists?

--- a/spec/unit/provider/rz_image/default_spec.rb
+++ b/spec/unit/provider/rz_image/default_spec.rb
@@ -11,33 +11,15 @@ describe Puppet::Type.type(:rz_image).provider(:default) do
     end
 
     it "with response should return the string" do
-      provider.should_receive(:razor).and_return(PSON.dump({
-        :response => "test",
-        }))
+      provider.should_receive(:razor).and_return("test")
       provider.create.should == "test"
-    end
-
-    it "with result should raise Puppet::Error" do
-      provider.should_receive(:razor).and_return(PSON.dump({
-        :result => "Invalid Metadata [root_password:'short']",
-        }))
-      expect { provider.create }.to raise_error(Puppet::Error)
     end
   end
 
   describe "#destroy" do
     it "with response should return the string" do
-      provider.should_receive(:razor).and_return(PSON.dump({
-        :response => ""
-        }))
+      provider.should_receive(:razor).and_return("")
       provider.destroy.should == ""
-    end
-
-    it "with result should raise Puppet::Error" do
-      provider.should_receive(:razor).and_return(PSON.dump({
-        :result => "invalid uuid [\"3qP9NNmv6xTIMfTpoP5k6M\"]",
-        }))
-      expect { provider.destroy }.to raise_error(Puppet::Error)
     end
   end
 end


### PR DESCRIPTION
This change reverts checking for errors in the image provider because
the image action of the razor command does not return PSON unlike the
other actions. Instead, the image provider now returns the output of
the razor command and always succeeds, like before.

Ideally, the image provider should look at the return value and raise a
Puppet::Error when failing to add an image. However, the razor command
always seems to return 0 and the output is awkward to parse. So, the
changes to the image provider should be reverted for now until the Razor
project is updated accordingly.

Closes #133
