### PR TITLE
Fixes bug #136

### DIFF
--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -8,9 +8,15 @@ class razor::nodejs(
   $directory
 ) {
   include nodejs
+  case $lsbdistcodename {
+    precise: { 
+      $real_ensure = '3.2.2' 
+    }
+    default: { $real_ensure = "present" }
+  }
 
   package { 'express':
-    ensure   => present,
+    ensure   => $real_ensure,
     provider => 'npm',
     require  => Package['npm'],
   }


### PR DESCRIPTION
This pegs the express version to 3.2.2 on ubuntu precise and sets ensure to 'present' for all other cases.

Resolves issue where any version of express > 3.2.2 results in a npm connect version incompatible with nodejs >= 0.8.0.
