### PR TITLE
(#136) Remove global nodejs `express` package installation

### DIFF
--- a/lib/puppet_x/puppet_labs/razor.rb
+++ b/lib/puppet_x/puppet_labs/razor.rb
@@ -149,7 +149,7 @@ module PuppetX::PuppetLabs
     def parse(response)
       begin
         result = PSON.parse(response)
-      rescue PSON::ParserError:
+      rescue PSON::ParserError
         # Leading line sometimes has a message for the command-line.
         response = response.split("\n").drop(1).join("\n")
         result = PSON.parse(response)

--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -9,12 +9,6 @@ class razor::nodejs(
 ) {
   include nodejs
 
-  package { 'express':
-    ensure   => present,
-    provider => 'npm',
-    require  => Package['npm'],
-  }
-
   nodejs::npm { "${directory}:express":
     ensure  => present,
     version => '2.5.11',

--- a/spec/classes/razor_nodejs_spec.rb
+++ b/spec/classes/razor_nodejs_spec.rb
@@ -19,10 +19,6 @@ describe 'razor::nodejs', :type => :class do
         }
       end
       it {
-        should contain_package('express').with(
-          :ensure   => 'present',
-          :provider => 'npm'
-        )
         should include_class('nodejs')
         should contain_nodejs__npm("#{params[:directory]}:express")
         should contain_nodejs__npm("#{params[:directory]}:mime")


### PR DESCRIPTION
The Razor module installed two versions of the nodejs `express` package, a
toolkit for writing your own web server on top of a basic HTTP accept loop.

One was installed in the Razor directory, pinned to an older version, and
fairly boringly functional.  This is the one that is actually used by Razor.

The other was a globally installed "latest" version, which was not actually
used, was kind of incompatible with the way Razor build its CGI interface, and
was incompatible with older versions of nodejs on, say, Ubuntu 12.04.

This just removes the global version: it served no actual purpose, other than
violating the nodejs community standards (throw stuff in your private
directory, no shared library code), and making Razor more apparently complex.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
