### PR TITLE
Add example for installing postgres database

### DIFF
--- a/examples/install-postgres.pp
+++ b/examples/install-postgres.pp
@@ -1,0 +1,11 @@
+class { 'postgresql::globals':
+  manage_package_repo => true,
+  version             => '9.2',
+}->
+
+class { 'postgresql::server': }
+
+postgresql::server::db { 'razor':
+  user     => 'razor',
+  password => postgresql_password('razor', 'mypass'),
+}


### PR DESCRIPTION
This example manifest deploys Postgres 9.2 which avoid the problem of starting
with an ancient version of postgres (8.4 on RHEL) that fails the database
migration task with the following error:

```
$ ./bin/razor-admin -e production migrate-database
...
Java::OrgPostgresqlUtil::PSQLException: ERROR: syntax error at or near
"DEFERRABLE"
```
